### PR TITLE
Add "colcon" to spell_check.words

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,4 +1,5 @@
 apache
+colcon
 iterdir
 pathlib
 pytest


### PR DESCRIPTION
To fix an error in CI

```
test/test_spell_check.py F..                                             [100%]
  
  =================================== FAILURES ===================================
  _______________________________ test_spell_check _______________________________
  
  known_words = ['apache', 'iterdir', 'pathlib', 'pytest', 'scspell', 'setuptools', ...]
  
      def test_spell_check(known_words):
          source_filenames = [Path(__file__).parents[1] / 'setup.py'] + \
              list(
                  (Path(__file__).parents[1] / 'colcon_awesome_pkg')
                  .glob('**/*.py')) + \
              list((Path(__file__).parents[1] / 'test').glob('**/*.py'))
      
          for source_filename in sorted(source_filenames):
              print('Spell checking:', source_filename)
      
          # check all files
          report = Report(known_words)
          spell_check(
              [str(p) for p in source_filenames], base_dicts=[SCSPELL_BUILTIN_DICT],
              report_only=report, additional_extensions=[('', 'Python')])
      
          unknown_word_count = len(report.unknown_words)
  >       assert unknown_word_count == 0, \
              'Found {unknown_word_count} unknown words: '.format_map(locals()) + \
              ', '.join(sorted(report.unknown_words))
  E       AssertionError: Found 1 unknown words: colcon
  E       assert 1 == 0
  
  test/test_spell_check.py:38: AssertionError
  ----------------------------- Captured stdout call -----------------------------
```