### PR TITLE
Modify __init__ copyright to include 'colcon' in dictionary

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ url = https://colcon.readthedocs.io
 project_urls =
   Changelog = https://github.com/colcon/template-package/milestones?direction=desc&sort=due_date&state=closed
   GitHub = https://github.com/colcon/template-package/
-author = Template Author
+author = Colcon Template Author
 author_email = templateauthor@example.com
 classifiers =
   Development Status :: 3 - Alpha

--- a/template_package/__init__.py
+++ b/template_package/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 Dirk Thomas
+# Copyright 2024 Colcon Template Author
 # Licensed under the Apache License, Version 2.0
 
 __version__ = '0.0.0'

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,4 +1,5 @@
 apache
+colcon
 iterdir
 linter
 pathlib


### PR DESCRIPTION
This should make it so that a trivial expansion of the template doesn't instantly make the tests fail, while still keeping the tests passing while not expanded. The "grep" operation in the expansion directions should make it obvious that the developer should replace the "Colcon Template Author" name with something appropriate.

This `__init__.py` is probably not copyrightable anyway, we just include a header to please test_copyright_license.py.

Closes: #1