### PR TITLE
Update deb platforms for release

### DIFF
--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -8,9 +8,8 @@ artifacts:
         config:
           repository: dirk-thomas/colcon
           distributions:
-            - ubuntu:bionic
             - ubuntu:focal
             - ubuntu:jammy
-            - debian:stretch
-            - debian:buster
-            - debian:bullseye
+            - ubuntu:noble
+            - debian:bookworm
+            - debian:trixie

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [template-package]
 No-Python2:
 Depends3: python3-colcon-core
-Suite: bionic focal jammy stretch buster bullseye
+Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
Added:
* Debian Bookworm (stable)
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Trixie (testing)

Dropped:
* Ubuntu Bionic (18.04 LTS)
* Debian Bullseye (oldstable)
* Debian Buster (oldoldstable)
* Debian Stretch (EOL)

Retained:
* Ubuntu Focal (20.04 LTS)
* Ubuntu Jammy (22.04 LTS)