### PR TITLE
Add workflow_dispatch trigger to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches: ['main']
   pull_request:
+  workflow_dispatch:
 
 jobs:
   pytest:


### PR DESCRIPTION
This allows users to trigger CI runs at any time from the GitHub Actions UI. We don't publish anything as part of the colcon/ci run, so it's safe to do and sometimes useful to investigate changes in our dependencies.