### PR TITLE
Add COLCON_IGNORE marker to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist/
 /*.egg-info/
 /.coverage
+/COLCON_IGNORE
 __pycache__/


### PR DESCRIPTION
I don't see any reason we'd ever want to commit this marker file, but I do use them from time to time to sanitize my colcon development workspace for spiking out features.