### PR TITLE
Run yamllint checks in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 ---
 name: Run tests
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches: ['main']
   pull_request:
@@ -10,3 +10,8 @@ on:
 jobs:
   pytest:
     uses: colcon/ci/.github/workflows/pytest.yaml@main
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: yamllint -f github .

--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -1,3 +1,4 @@
+---
 artifacts:
   - type: wheel
     uploads:


### PR DESCRIPTION
Longer term, it might be better to develop a test/test_yamllint.py or something, but we're already using this approach elsewhere in the colcon org.