### PR TITLE
Add dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Already used by colcon/ci, but this will ensure that actions/checkout stays up-to-date, and will help with any other GitHub Actions that colcon developers add to their own extensions.